### PR TITLE
Feat presentation block

### DIFF
--- a/astro/src/components/blocks/BlockManager.astro
+++ b/astro/src/components/blocks/BlockManager.astro
@@ -4,7 +4,7 @@ import Hero from "./Hero.astro";
 import Team from "./Team.astro";
 import Cards from "./Cards.astro";
 import Stats from "./Stats.astro";
-
+import GridList from "./GridList.astro";
 interface Block {
 	__component: string;
 	id: number;
@@ -24,6 +24,7 @@ const componentMap: Record<string, any> = {
 	"blocks.team": Team,
 	"blocks.cards": Cards,
 	"blocks.stats": Stats,
+	"blocks.grid-list": GridList,
 };
 ---
 

--- a/astro/src/components/blocks/GridList.astro
+++ b/astro/src/components/blocks/GridList.astro
@@ -1,0 +1,83 @@
+---
+import { marked } from "marked";
+import NotchArrow from "@components/shared/NotchArrow.astro";
+import AvegaTitle from "@components/shared/AvegaTitle.astro";
+import Card from "@components/shared/Card.astro";
+
+interface CardData {
+	title: string;
+	subtitle?: string;
+	description: string;
+	icon?: string;
+	backgroundImage?: {
+		url: string;
+		alternativeText: string;
+	};
+}
+
+interface Props {
+  zIndex: number;
+	title: string;
+  content: string;
+  cards: CardData[];
+  hasNotch: boolean;
+  previousBlockHasNotch: boolean;
+}
+
+
+const { zIndex, title, content, cards, hasNotch, previousBlockHasNotch } = Astro.props;
+
+// Configure marked to properly handle markdown
+marked.setOptions({
+  breaks: true,
+  gfm: true // GitHub Flavored Markdown
+});
+
+const parsedContent = content ? marked.parse(content) : null;
+
+const sectionId = `presentation-${zIndex}`;
+---
+<section style={`z-index: ${zIndex}`} class=`relative overflow-hidden ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}`>
+  <div data-section-id={sectionId} class=`relative bg-white`>
+    <div class="mx-auto max-w-screen-xl px-8 py-48">
+      {title && (
+        <AvegaTitle title={title} level={4} color="#725CFA" />
+      )}
+
+      <div class="mt-4 prose prose-strong:font-bold max-w-none">
+        <div set:html={parsedContent} />
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-12 items-start mt-10">
+        {cards.map((card) => (
+          <Card
+            title={card.title}
+            subtitle={card.subtitle}
+            description={card.description}
+            icon={card.icon}
+            backgroundImage={card.backgroundImage}
+          />
+        ))}
+      </div>
+    </div>
+
+    {hasNotch && (
+      <NotchArrow color={"#7666FC"} />
+   )}
+  </div>
+</section>
+
+
+{hasNotch && (
+  <script define:vars={{ sectionId }}>
+    const section = document.querySelector(`[data-section-id="${sectionId}"]`);
+    if (section) {
+      import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
+        applySectionClipPathWithBorder({
+          section,
+          borderColor: "#ffffff",
+        });
+      });
+    }
+  </script>
+)}

--- a/astro/src/components/shared/AvegaTitle.astro
+++ b/astro/src/components/shared/AvegaTitle.astro
@@ -1,11 +1,14 @@
 ---
+import { hexToRgba } from "@lib/colorUtils";
+
 interface Props {
 	title: string;
 	level?: 1 | 2 | 3 | 4 | 5 | 6;
+	color?: string;
 	className?: string;
 }
 
-const { title, level = 1, className } = Astro.props;
+const { title, level = 1, className, color = "#ffffff" } = Astro.props;
 const Tag = `h${level}` as keyof HTMLElementTagNameMap;
 
 // Define text sizes based on heading level
@@ -19,10 +22,16 @@ const textSizeClasses = {
 };
 
 const sizeClass = textSizeClasses[level];
+
+const shadowColor = hexToRgba(color, 0.16);
 ---
 
 <Tag
-    class={`avega ${sizeClass} text-white max-w-4xl mt-6 relative z-10 ${className}`}
-    style="text-shadow: 5px 5px 0px rgba(255, 255, 255, 0.15);">
+    class={`avega ${sizeClass} max-w-4xl mt-6 relative z-10 ${className}`}
+    style={{
+		"color": color,
+        "text-shadow": `5px 5px 0px ${shadowColor}`,
+    }}
+>
     <Fragment set:html={title} />
 </Tag>

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -21,7 +21,8 @@
         "blocks.features",
         "blocks.team",
         "blocks.cards",
-        "blocks.stats"
+        "blocks.stats",
+        "blocks.grid-list"
       ]
     }
   }

--- a/strapi/src/components/blocks/grid-list.json
+++ b/strapi/src/components/blocks/grid-list.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_blocks_grid_lists",
+  "info": {
+    "displayName": "GridList",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "cards": {
+      "type": "component",
+      "repeatable": true,
+      "component": "components.card"
+    },
+    "hasNotch": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-05T08:22:30.878Z"
+    "x-generation-date": "2025-07-11T10:24:30.103Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -4786,6 +4786,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/BlocksStatsComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlocksGridListComponent"
                     }
                   ]
                 },
@@ -4796,7 +4799,8 @@
                     "blocks.features": "#/components/schemas/BlocksFeaturesComponent",
                     "blocks.team": "#/components/schemas/BlocksTeamComponent",
                     "blocks.cards": "#/components/schemas/BlocksCardsComponent",
-                    "blocks.stats": "#/components/schemas/BlocksStatsComponent"
+                    "blocks.stats": "#/components/schemas/BlocksStatsComponent",
+                    "blocks.grid-list": "#/components/schemas/BlocksGridListComponent"
                   }
                 }
               },
@@ -4886,6 +4890,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/BlocksStatsComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/BlocksGridListComponent"
                 }
               ]
             },
@@ -4896,7 +4903,8 @@
                 "blocks.features": "#/components/schemas/BlocksFeaturesComponent",
                 "blocks.team": "#/components/schemas/BlocksTeamComponent",
                 "blocks.cards": "#/components/schemas/BlocksCardsComponent",
-                "blocks.stats": "#/components/schemas/BlocksStatsComponent"
+                "blocks.stats": "#/components/schemas/BlocksStatsComponent",
+                "blocks.grid-list": "#/components/schemas/BlocksGridListComponent"
               }
             }
           },
@@ -4969,6 +4977,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/BlocksStatsComponent"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BlocksGridListComponent"
                       }
                     ]
                   },
@@ -4979,7 +4990,8 @@
                       "blocks.features": "#/components/schemas/BlocksFeaturesComponent",
                       "blocks.team": "#/components/schemas/BlocksTeamComponent",
                       "blocks.cards": "#/components/schemas/BlocksCardsComponent",
-                      "blocks.stats": "#/components/schemas/BlocksStatsComponent"
+                      "blocks.stats": "#/components/schemas/BlocksStatsComponent",
+                      "blocks.grid-list": "#/components/schemas/BlocksGridListComponent"
                     }
                   }
                 },
@@ -5199,6 +5211,9 @@
           },
           "button": {
             "$ref": "#/components/schemas/ComponentsLinkComponent"
+          },
+          "hasNotch": {
+            "type": "boolean"
           }
         }
       },
@@ -5483,6 +5498,9 @@
           },
           "variant": {
             "type": "string"
+          },
+          "hasNotch": {
+            "type": "boolean"
           }
         }
       },
@@ -5652,6 +5670,135 @@
           },
           "icon": {
             "type": "string"
+          },
+          "backgroundImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -5808,6 +5955,9 @@
               "blue",
               "purple"
             ]
+          },
+          "hasNotch": {
+            "type": "boolean"
           }
         }
       },
@@ -5842,6 +5992,38 @@
               "default",
               "dark"
             ]
+          },
+          "hasNotch": {
+            "type": "boolean"
+          }
+        }
+      },
+      "BlocksGridListComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "blocks.grid-list"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "cards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ComponentsCardComponent"
+            }
+          },
+          "hasNotch": {
+            "type": "boolean"
           }
         }
       },

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -32,6 +32,20 @@ export interface BlocksFeatures extends Struct.ComponentSchema {
   };
 }
 
+export interface BlocksGridList extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_grid_lists';
+  info: {
+    description: '';
+    displayName: 'GridList';
+  };
+  attributes: {
+    cards: Schema.Attribute.Component<'components.card', true>;
+    content: Schema.Attribute.RichText;
+    hasNotch: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    title: Schema.Attribute.String;
+  };
+}
+
 export interface BlocksHero extends Struct.ComponentSchema {
   collectionName: 'components_heroes';
   info: {
@@ -120,6 +134,7 @@ declare module '@strapi/strapi' {
     export interface ComponentSchemas {
       'blocks.cards': BlocksCards;
       'blocks.features': BlocksFeatures;
+      'blocks.grid-list': BlocksGridList;
       'blocks.hero': BlocksHero;
       'blocks.stats': BlocksStats;
       'blocks.team': BlocksTeam;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -450,6 +450,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         'blocks.team',
         'blocks.cards',
         'blocks.stats',
+        'blocks.grid-list',
       ]
     >;
     createdAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
This pull request introduces a new `GridList` block component. 
The changes include adding the `GridList` component to the Astro frontend and Strapi backend.

### Frontend Changes (Astro):

* **`GridList` Component Implementation**: Added a new `GridList.astro` component that supports a customizable title, markdown content, and a grid of cards.
* **Block Manager Update**: Registered the `GridList` component in the `BlockManager.astro` file to map the new block type (`blocks.grid-list`) to the `GridList` component. [[1]](diffhunk://#diff-f109f07a6040db1a55692d1b937d5000b445a12891a8f1fa5bd80ccbaf7547d4L7-R7) [[2]](diffhunk://#diff-f109f07a6040db1a55692d1b937d5000b445a12891a8f1fa5bd80ccbaf7547d4R27)

### Backend Changes (Strapi):

* **Content Type Schema**: Added a new schema definition for the `GridList` block in `grid-list.json`, including attributes like `title`, `content`, `cards`, and `hasNotch`.

### Shared Component Enhancements:

* **`AvegaTitle` Enhancements**: Updated the `AvegaTitle.astro` component to accept a `color` prop for customizable text colors and adjusted its `text-shadow` styling dynamically based on the provided color. [[1]](diffhunk://#diff-5d1717c9dc86bf437c15ece56d76c9933a8b7efa84cd86c79902a7d6808dd535R2-R11) [[2]](diffhunk://#diff-5d1717c9dc86bf437c15ece56d76c9933a8b7efa84cd86c79902a7d6808dd535R25-R35)

___
Closes #6