### PR TITLE
feat: add Highlight block and extend Button component with new style variants

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.9",
     "astro": "^5.4.2",
+    "class-variance-authority": "^0.7.1",
     "date-fns": "^4.1.0",
     "lefthook": "^1.11.10",
     "marked": "^15.0.7",

--- a/astro/src/components/blocks/BlockManager.astro
+++ b/astro/src/components/blocks/BlockManager.astro
@@ -6,6 +6,7 @@ import Cards from "./Cards.astro";
 import Stats from "./Stats.astro";
 import GridList from "./GridList.astro";
 import Timeline from "./Timeline.astro";
+import Highlight from "./Highlight.astro";
 
 interface Block {
 	__component: string;
@@ -28,6 +29,7 @@ const componentMap: Record<string, any> = {
 	"blocks.stats": Stats,
 	"blocks.grid-list": GridList,
 	"blocks.timeline": Timeline,
+	"blocks.highlight": Highlight,
 };
 ---
 

--- a/astro/src/components/blocks/Hero.astro
+++ b/astro/src/components/blocks/Hero.astro
@@ -8,20 +8,20 @@ import { Image } from "astro:assets";
 import NotchArrow from "@components/shared/NotchArrow.astro";
 
 interface Props {
-   zIndex: number;
-	title: string;
-	description: string;
-	backgroundImage: {
-		url: string;
-		alternativeText: string;
-	};
-	button: {
-		title: string;
-		url: string;
-		target: "_blank" | "_self" | "_parent" | "_top";
-	};
-   hasNotch: boolean;
-   previousBlockHasNotch: boolean;
+    zIndex: number;
+    title: string;
+    description: string;
+    backgroundImage: {
+        url: string;
+        alternativeText: string;
+    };
+    button: {
+        title: string;
+        url: string;
+        target: "_blank" | "_self" | "_parent" | "_top";
+    };
+    hasNotch: boolean;
+    previousBlockHasNotch: boolean;
 }
 
 const strapiUrl = import.meta.env.STRAPI_URL;
@@ -31,14 +31,13 @@ const { zIndex, title, description, backgroundImage, button, hasNotch, previousB
 const imageUrl = getImageUrl(backgroundImage.url, strapiUrl);
 // Configure marked to properly handle markdown
 marked.setOptions({
-  breaks: true,
-  gfm: true // GitHub Flavored Markdown
+    breaks: true,
+    gfm: true, // GitHub Flavored Markdown
 });
 
 const parsedContent = description ? marked.parse(description) : null;
 
 const sectionId = `hero-${zIndex}`;
-
 ---
 
 <section class=`overflow-hidden relative h-screen ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}` style={{
@@ -62,6 +61,7 @@ const sectionId = `hero-${zIndex}`;
          {button && (
             <div class="mt-18">
                <Button 
+                  variant="shadow"
                   text={button.title}
                   target={button.target}
                   url={button.url}

--- a/astro/src/components/blocks/Highlight.astro
+++ b/astro/src/components/blocks/Highlight.astro
@@ -27,8 +27,7 @@ const sectionId = `highlight-${zIndex}`;
 ---
 <section class={cn("relative overflow-hidden", hasNotch && 'pb-notch', previousBlockHasNotch && 'mt-notch')} style={`z-index: ${zIndex}`}>
   <div data-section-id={sectionId} class="relative bg-white">
-
-    <div class="mx-auto max-w-screen-xl px-16 py-48 relative z-10 flex flex-col lg:flex-row-reverse justify-center items-center gap-32">
+    <div class="mx-auto max-w-screen-xl px-8 sm:px-16 py-48 relative z-10 flex flex-col lg:flex-row-reverse justify-center items-center gap-32">
         <div class="max-w-lg md:max-w-none">
             {title && (
                 <AvegaTitle title={title} level={4} color="#725CFA" />

--- a/astro/src/components/blocks/Highlight.astro
+++ b/astro/src/components/blocks/Highlight.astro
@@ -1,0 +1,74 @@
+---
+import Button from "@components/shared/Button.astro";
+import NotchArrow from "@components/shared/NotchArrow.astro";
+import { cn } from "@lib/cn";
+import { configureMarkdown, parseMarkdown } from "@lib/markdown";
+import AvegaTitle from "../shared/AvegaTitle.astro";
+
+interface Props {
+    zIndex: number;
+    title: string;
+    content: string;
+    ctaText?: string;
+    ctaLink?: string;
+    splineURL?: string;
+    hasNotch: boolean;
+    previousBlockHasNotch: boolean;
+}
+
+const { zIndex, title, content, splineURL, ctaText, ctaLink, hasNotch, previousBlockHasNotch } = Astro.props;
+
+// Configure marked for markdown parsing
+configureMarkdown();
+
+const parsedContent = parseMarkdown(content);
+
+const sectionId = `highlight-${zIndex}`;
+---
+<section class={cn("relative overflow-hidden", hasNotch && 'pb-notch', previousBlockHasNotch && 'mt-notch')} style={`z-index: ${zIndex}`}>
+  <div data-section-id={sectionId} class="relative bg-white">
+
+    <div class="mx-auto max-w-screen-xl px-16 py-48 relative z-10 flex flex-col lg:flex-row-reverse justify-center items-center gap-32">
+        <div class="max-w-lg md:max-w-none">
+            {title && (
+                <AvegaTitle title={title} level={4} color="#725CFA" />
+            )}
+
+            <div class="mt-4 prose prose-strong:font-bold max-w-none" set:html={parsedContent}></div>
+
+            {ctaText && (
+                <Button 
+                    text={ctaText}
+                    target={ctaLink ? "_blank" : "_self"}
+                    url={ctaLink ?? ""}
+                    className="mt-10"
+                />
+            )}
+        </div>
+
+        {splineURL && (
+            <div class="max-w-sm w-full shrink-0">
+                <iframe src={splineURL} class="w-full aspect-square rounded-full"></iframe>
+            </div>
+        )}
+    </div>
+
+    {hasNotch && (
+      <NotchArrow color="#9A89FD" />
+   )}
+  </div>
+</section> 
+
+{hasNotch && (
+	<script define:vars={{ sectionId }}>
+		const section = document.querySelector(`[data-section-id="${sectionId}"]`);
+		if (section) {
+		import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
+			applySectionClipPathWithBorder({
+			section,
+			borderColor: "#1B1C5D",
+			});
+		});
+		}
+	</script>
+)}

--- a/astro/src/components/blocks/Stats.astro
+++ b/astro/src/components/blocks/Stats.astro
@@ -1,69 +1,70 @@
 ---
+import Button from "@components/shared/Button.astro";
+import NotchArrow from "@components/shared/NotchArrow.astro";
+import { marked } from "marked";
 import AvegaTitle from "../shared/AvegaTitle.astro";
 import StatCard from "../shared/StatCard.astro";
-import { marked } from 'marked';
-import NotchArrow from "@components/shared/NotchArrow.astro";
 
 interface StatCardData {
-  icon: string;
-  title: string;
-  subtitle?: string;
+    icon: string;
+    title: string;
+    subtitle?: string;
 }
 
 interface Props {
-  zIndex: number;
-  title: string;
-  content: string;
-  stats: StatCardData[];
-  ctaText?: string;
-  ctaLink?: string;
-  variant?: "default" | "dark";
-  hasNotch: boolean;
-  previousBlockHasNotch: boolean;
+    zIndex: number;
+    title: string;
+    content: string;
+    stats: StatCardData[];
+    ctaText?: string;
+    ctaLink?: string;
+    variant?: "default" | "dark";
+    hasNotch: boolean;
+    previousBlockHasNotch: boolean;
 }
 
 const { zIndex, title, content, stats = [], ctaText, ctaLink, variant = "dark", hasNotch, previousBlockHasNotch } = Astro.props;
 
 // Configure marked for markdown parsing
 marked.setOptions({
-  breaks: true,
-  gfm: true
+    breaks: true,
+    gfm: true,
 });
 
 const parsedContent = content ? marked.parse(content) : null;
-const sectionStyle = variant === "dark" ? `background-color: #191958` : 'white';
+const sectionStyle = variant === "dark" ? "background-color: #191958" : "white";
 const statsCount = stats?.length || 0;
 
 // Define grid layout configurations
 const gridLayouts = {
-  1: { 
-    container: "grid grid-cols-1 gap-4 mb-8 max-w-md mx-auto",
-    pattern: [1]
-  },
-  2: { 
-    container: "grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 max-w-2xl mx-auto",
-    pattern: [1, 1]
-  },
-  3: { 
-    container: "grid grid-cols-3 gap-4 mb-8",
-    pattern: [2, 1, 3] // 2-1-3 pattern
-  },
-  4: { 
-    container: "grid grid-cols-3 gap-4 mb-8",
-    pattern: [2, 1, 1, 2] // 2-1-1-2 pattern
-  },
-  5: { 
-    container: "grid grid-cols-3 gap-4 mb-8",
-    pattern: [2, 1, 1, 1, 2] // 2-1-1-1-2 pattern
-  },
-  6: { 
-    container: "grid grid-cols-3 gap-4 mb-8",
-    pattern: [2, 1, 1, 2, 2, 1] // 2-1-1-2-2-1 pattern
-  },
-  default: { 
-    container: "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8",
-    pattern: []
-  }
+    1: {
+        container: "grid grid-cols-1 gap-4 mb-8 max-w-md mx-auto",
+        pattern: [1],
+    },
+    2: {
+        container: "grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 max-w-2xl mx-auto",
+        pattern: [1, 1],
+    },
+    3: {
+        container: "grid grid-cols-3 gap-4 mb-8",
+        pattern: [2, 1, 3], // 2-1-3 pattern
+    },
+    4: {
+        container: "grid grid-cols-3 gap-4 mb-8",
+        pattern: [2, 1, 1, 2], // 2-1-1-2 pattern
+    },
+    5: {
+        container: "grid grid-cols-3 gap-4 mb-8",
+        pattern: [2, 1, 1, 1, 2], // 2-1-1-1-2 pattern
+    },
+    6: {
+        container: "grid grid-cols-3 gap-4 mb-8",
+        pattern: [2, 1, 1, 2, 2, 1], // 2-1-1-2-2-1 pattern
+    },
+    default: {
+        container: "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8",
+        pattern: [],
+    },
 };
 
 const currentLayout = gridLayouts[statsCount as keyof typeof gridLayouts] || gridLayouts.default;
@@ -114,13 +115,16 @@ const sectionId = `stats-${zIndex}`;
             </div>
 
             {ctaText && (
+
               <div class="flex items-center gap-4">
-                <a 
-                  href={ctaLink || "#"} 
-                  class="inline-flex items-center px-6 py-3 bg-white text-[#191958] rounded-full font-semibold hover:bg-opacity-90 transition-all"
-                >
-                  {ctaText}
-                </a>
+                <Button 
+                  variant="outline"
+                  text={ctaText}
+                  target={ctaLink ? "_blank" : "_self"}
+                  url={ctaLink ?? ""}
+                />
+
+            
                 <a 
                   href="https://linkedin.com" 
                   target="_blank" 

--- a/astro/src/components/shared/Button.astro
+++ b/astro/src/components/shared/Button.astro
@@ -1,20 +1,37 @@
 ---
+import { cn } from "@lib/cn";
 import { getLinkUrl } from "@lib/imageUtils";
+import { cva } from "class-variance-authority";
 
 interface Props {
-	text: string;
-	url: string;
-	target: "_blank" | "_self" | "_parent" | "_top";
+    variant?: "default" | "shadow" | "outline";
+    text: string;
+    url: string;
+    target: "_blank" | "_self" | "_parent" | "_top";
+    className?: string;
 }
 
-const { text, url, target } = Astro.props;
+const { text, url, target, variant = "default", className } = Astro.props;
 const baseUrl = import.meta.env.BASE_URL;
 const href = getLinkUrl(url, baseUrl);
----
 
- <a href={href} target={target ?? '_self'} class="relative px-8 py-2.5 font-semibold text-white group">
-    <span class="absolute rounded-sm inset-0 w-full h-full transition duration-300 ease-out transform translate-x-1 translate-y-1 group-hover:translate-x-0 group-hover:translate-y-0"
-            style="background-color: rgba(255, 255, 255, 0.10);"></span>
-    <span class="absolute inset-0 w-full h-full border-1 rounded-sm border-white"></span>
-    <span class="relative">{text}</span>
+const buttonVariants = cva("px-8 py-2.5 rounded-md font-semibold inline-flex", {
+    variants: {
+        variant: {
+            default: "bg-[#725CFA] text-white hover:bg-[#725CFA]/90",
+            shadow: "border-1 border-white bg-transparent text-white relative after:content-[''] after:absolute after:inset-0 after:rounded-md after:translate-x-1 after:translate-y-1 after:bg-white/10 after:z-[-1] hover:after:translate-x-0 hover:after:translate-y-0 after:transition-all after:duration-300 after:ease-out",
+            outline: "border-1 border-white bg-transparent text-white relative hover:bg-white/10 transition-all duration-300 ease-out",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+    },
+});
+---
+<a
+  href={href}
+  target={target ?? "_self"}
+  class={cn(buttonVariants({ variant: variant }), className)}
+>
+  {text}
 </a>

--- a/astro/yarn.lock
+++ b/astro/yarn.lock
@@ -2090,6 +2090,13 @@ cjs-module-lexer@^1.2.2:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
+class-variance-authority@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz#4008a798a0e4553a781a57ac5177c9fb5d043787"
+  integrity sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==
+  dependencies:
+    clsx "^2.1.1"
+
 cli-boxes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -23,7 +23,8 @@
         "blocks.cards",
         "blocks.stats",
         "blocks.grid-list",
-        "blocks.timeline"
+        "blocks.timeline",
+        "blocks.highlight"
       ]
     }
   }

--- a/strapi/src/components/blocks/highlight.json
+++ b/strapi/src/components/blocks/highlight.json
@@ -1,0 +1,29 @@
+{
+  "collectionName": "components_blocks_highlights",
+  "info": {
+    "displayName": "Highlight",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "splineURL": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "ctaText": {
+      "type": "string"
+    },
+    "ctaLink": {
+      "type": "string"
+    },
+    "hasNotch": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-11T13:01:31.880Z"
+    "x-generation-date": "2025-07-11T21:50:12.713Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -4792,6 +4792,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/BlocksTimelineComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlocksHighlightComponent"
                     }
                   ]
                 },
@@ -4804,7 +4807,8 @@
                     "blocks.cards": "#/components/schemas/BlocksCardsComponent",
                     "blocks.stats": "#/components/schemas/BlocksStatsComponent",
                     "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
-                    "blocks.timeline": "#/components/schemas/BlocksTimelineComponent"
+                    "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
+                    "blocks.highlight": "#/components/schemas/BlocksHighlightComponent"
                   }
                 }
               },
@@ -4900,6 +4904,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/BlocksTimelineComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/BlocksHighlightComponent"
                 }
               ]
             },
@@ -4912,7 +4919,8 @@
                 "blocks.cards": "#/components/schemas/BlocksCardsComponent",
                 "blocks.stats": "#/components/schemas/BlocksStatsComponent",
                 "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
-                "blocks.timeline": "#/components/schemas/BlocksTimelineComponent"
+                "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
+                "blocks.highlight": "#/components/schemas/BlocksHighlightComponent"
               }
             }
           },
@@ -4991,6 +4999,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/BlocksTimelineComponent"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BlocksHighlightComponent"
                       }
                     ]
                   },
@@ -5003,7 +5014,8 @@
                       "blocks.cards": "#/components/schemas/BlocksCardsComponent",
                       "blocks.stats": "#/components/schemas/BlocksStatsComponent",
                       "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
-                      "blocks.timeline": "#/components/schemas/BlocksTimelineComponent"
+                      "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
+                      "blocks.highlight": "#/components/schemas/BlocksHighlightComponent"
                     }
                   }
                 },
@@ -6062,6 +6074,38 @@
             "items": {
               "$ref": "#/components/schemas/ComponentsCardComponent"
             }
+          },
+          "hasNotch": {
+            "type": "boolean"
+          }
+        }
+      },
+      "BlocksHighlightComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "blocks.highlight"
+            ]
+          },
+          "splineURL": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "ctaText": {
+            "type": "string"
+          },
+          "ctaLink": {
+            "type": "string"
           },
           "hasNotch": {
             "type": "boolean"

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -64,6 +64,22 @@ export interface BlocksHero extends Struct.ComponentSchema {
   };
 }
 
+export interface BlocksHighlight extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_highlights';
+  info: {
+    description: '';
+    displayName: 'Highlight';
+  };
+  attributes: {
+    content: Schema.Attribute.RichText;
+    ctaLink: Schema.Attribute.String;
+    ctaText: Schema.Attribute.String;
+    hasNotch: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    splineURL: Schema.Attribute.String;
+    title: Schema.Attribute.String;
+  };
+}
+
 export interface BlocksStats extends Struct.ComponentSchema {
   collectionName: 'components_blocks_stats';
   info: {
@@ -150,6 +166,7 @@ declare module '@strapi/strapi' {
       'blocks.features': BlocksFeatures;
       'blocks.grid-list': BlocksGridList;
       'blocks.hero': BlocksHero;
+      'blocks.highlight': BlocksHighlight;
       'blocks.stats': BlocksStats;
       'blocks.team': BlocksTeam;
       'blocks.timeline': BlocksTimeline;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -452,6 +452,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         'blocks.stats',
         'blocks.grid-list',
         'blocks.timeline',
+        'blocks.highlight',
       ]
     >;
     createdAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
This pull request introduces a new `Highlight` block  and updates the `Button` component to support additional styles.

### New `Highlight` Block

* Added a new `Highlight.astro` component with support for titles, content, CTAs, spline URLs, and notch styling. This includes markdown parsing and dynamic styling. 
* Registered the `Highlight` block in the `BlockManager.astro` component, enabling it to be used in the block system. 
* Updated the Strapi schema to include the `Highlight` block, defining its attributes such as `title`, `content`, and `ctaLink`.
* Extended the Strapi documentation to include the `Highlight` block in the API schema. 

### Enhancements to the `Button` Component

* Refactored the `Button.astro` component to support three variants: `default`, `shadow`, and `outline`, using the `class-variance-authority` library for styling. (`astro/src/components/shared/Button.astro`)
* Updated the `Hero` and `Stats` components to use the new `Button` variants (`shadow` and `outline`, respectively). 

### Dependency Updates

* Added the `class-variance-authority` package to `astro/package.json` to support dynamic class management. 

___
Closes #3