### PR TITLE
fix: avoid dynamic imports when hasNotch

### DIFF
--- a/astro/src/components/blocks/Cards.astro
+++ b/astro/src/components/blocks/Cards.astro
@@ -47,7 +47,7 @@ const sectionId = `cards-${zIndex}`;
 <section class=`relative overflow-hidden ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}` style={{
    zIndex: zIndex
 }}>
-	<div data-section-id={sectionId} class="relative w-full py-48 mx-auto">
+	<div data-section-id={sectionId} class={`relative w-full py-48 mx-auto`} data-notch-border-color={hasNotch ? '#6336E4' : undefined}>
 		{imageUrl && (
 			<Image 
 				src={imageUrl}
@@ -83,20 +83,4 @@ const sectionId = `cards-${zIndex}`;
 			<NotchArrow color="#ffffff" />
 		)}
 	</div>
-
 </section>
-
- 
-{hasNotch && (
-	<script define:vars={{ sectionId }}>
-		const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-		if (section) {
-		import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-			applySectionClipPathWithBorder({
-			section,
-			borderColor: "#6336E4",
-			});
-		});
-		}
-	</script>
-)}

--- a/astro/src/components/blocks/Features.astro
+++ b/astro/src/components/blocks/Features.astro
@@ -74,7 +74,7 @@ const sectionId = `features-${zIndex}`;
 
 
 <section style={`z-index: ${zIndex}`} class=`relative overflow-hidden ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}`>
-  <div data-section-id={sectionId} class=`relative mx-auto` style={sectionStyle}>
+  <div data-section-id={sectionId} class={`relative mx-auto`} style={sectionStyle} data-notch-border-color={hasNotch ? variantColor : undefined}>
     <!-- Decorative blurred circles - only show for dark variant -->
     {variant === "dark" && (
       <>
@@ -236,21 +236,6 @@ const sectionId = `features-${zIndex}`;
 
     {hasNotch && (
       <NotchArrow color={arrowColor} />
-   )}
+    )}
   </div>
 </section>
-
-
-{hasNotch && (
-  <script define:vars={{ sectionId, variantColor }}>
-    const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-    if (section) {
-      import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-        applySectionClipPathWithBorder({
-          section,
-          borderColor: variantColor,
-        });
-      });
-    }
-  </script>
-)}

--- a/astro/src/components/blocks/GridList.astro
+++ b/astro/src/components/blocks/GridList.astro
@@ -38,7 +38,7 @@ const parsedContent = content ? marked.parse(content) : null;
 const sectionId = `presentation-${zIndex}`;
 ---
 <section style={`z-index: ${zIndex}`} class=`relative overflow-hidden ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}`>
-  <div data-section-id={sectionId} class=`relative bg-white`>
+  <div data-section-id={sectionId} class={`relative bg-white`} data-notch-border-color={hasNotch ? '#7666FC' : undefined}>
     <div class="mx-auto max-w-screen-xl px-8 py-48">
       {title && (
         <AvegaTitle title={title} level={4} color="#725CFA" />
@@ -66,18 +66,3 @@ const sectionId = `presentation-${zIndex}`;
    )}
   </div>
 </section>
-
-
-{hasNotch && (
-  <script define:vars={{ sectionId }}>
-    const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-    if (section) {
-      import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-        applySectionClipPathWithBorder({
-          section,
-          borderColor: "#ffffff",
-        });
-      });
-    }
-  </script>
-)}

--- a/astro/src/components/blocks/Hero.astro
+++ b/astro/src/components/blocks/Hero.astro
@@ -43,7 +43,7 @@ const sectionId = `hero-${zIndex}`;
 <section class=`overflow-hidden relative h-screen ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}` style={{
    zIndex: zIndex
 }}>
-   <div data-section-id={sectionId} class="h-full overflow-hidden relative flex flex-col items-center justify-center" >
+   <div data-section-id={sectionId} class={`h-full overflow-hidden relative flex flex-col items-center justify-center`} data-notch-border-color={hasNotch ? '#6336E4' : undefined}>
       {imageUrl && (
          <Image src={imageUrl}
             alt=""
@@ -76,17 +76,3 @@ const sectionId = `hero-${zIndex}`;
    </div>
 </section>
 
-
-{hasNotch && (
-   <script define:vars={{ sectionId }}>
-     const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-     if (section) {
-       import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-         applySectionClipPathWithBorder({
-           section,
-           borderColor: "#6336E4",
-         });
-       });
-     }
-   </script>
- )}

--- a/astro/src/components/blocks/Highlight.astro
+++ b/astro/src/components/blocks/Highlight.astro
@@ -26,7 +26,7 @@ const parsedContent = parseMarkdown(content);
 const sectionId = `highlight-${zIndex}`;
 ---
 <section class={cn("relative overflow-hidden", hasNotch && 'pb-notch', previousBlockHasNotch && 'mt-notch')} style={`z-index: ${zIndex}`}>
-  <div data-section-id={sectionId} class="relative bg-white">
+  <div data-section-id={sectionId} class={`relative bg-white`} data-notch-border-color={hasNotch ? '#1B1C5D' : undefined}>
     <div class="mx-auto max-w-screen-xl px-8 sm:px-16 py-48 relative z-10 flex flex-col lg:flex-row-reverse justify-center items-center gap-32">
         <div class="max-w-lg md:max-w-none">
             {title && (
@@ -56,18 +56,4 @@ const sectionId = `highlight-${zIndex}`;
       <NotchArrow color="#9A89FD" />
    )}
   </div>
-</section> 
-
-{hasNotch && (
-	<script define:vars={{ sectionId }}>
-		const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-		if (section) {
-		import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-			applySectionClipPathWithBorder({
-			section,
-			borderColor: "#1B1C5D",
-			});
-		});
-		}
-	</script>
-)}
+</section>

--- a/astro/src/components/blocks/Stats.astro
+++ b/astro/src/components/blocks/Stats.astro
@@ -74,7 +74,7 @@ const sectionId = `stats-${zIndex}`;
 <section class={`relative overflow-hidden ${hasNotch ? 'pb-notch' : ''} ${previousBlockHasNotch ? 'mt-notch' : ''}`} style={{
   zIndex: zIndex
 }}>
-  <div data-section-id={sectionId} class="relative" style={sectionStyle}>
+  <div data-section-id={sectionId} class={`relative`} style={sectionStyle} data-notch-border-color={hasNotch ? '#1B1C5D' : undefined}>
     <!-- Decorative blurred circles for dark variant -->
     {variant === "dark" && (
       <div class="absolute top-0 left-24 w-[32rem] h-[32rem] rounded-full filter blur-3xl blur-circle"></div>
@@ -147,17 +147,3 @@ const sectionId = `stats-${zIndex}`;
    )}
   </div>
 </section> 
-
-{hasNotch && (
-	<script define:vars={{ sectionId }}>
-		const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-		if (section) {
-		import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-			applySectionClipPathWithBorder({
-			section,
-			borderColor: "#1B1C5D",
-			});
-		});
-		}
-	</script>
-)}

--- a/astro/src/components/blocks/Team.astro
+++ b/astro/src/components/blocks/Team.astro
@@ -51,7 +51,7 @@ const cardImageUrl = getImageUrl(cardImage?.url, strapiUrl);
 const sectionId = `team-${zIndex}`;
 ---
 <section class={cn("relative overflow-hidden text-gray-600 body-font", hasNotch && "pb-notch", previousBlockHasNotch && "mt-notch")} style={`z-index: ${zIndex}`}>
-  <div data-section-id={sectionId} class="relative bg-white">
+  <div data-section-id={sectionId} class={`relative bg-white`} data-notch-border-color={hasNotch ? '#ff00ff' : undefined}>
     <div class="max-w-screen-xl mx-auto px-8 py-24">
       <div class="mb-20">
         <AvegaTitle title={title} color="#725CFA" level={4} />
@@ -71,17 +71,3 @@ const sectionId = `team-${zIndex}`;
     )}
   </div>
 </section>
-
-{hasNotch && (
-  <script define:vars={{ sectionId }}>
-    const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-    if (section) {
-      import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-        applySectionClipPathWithBorder({
-          section,
-          borderColor: "#ff00ff",
-        });
-      });
-    }
-  </script>
-)}

--- a/astro/src/components/blocks/Timeline.astro
+++ b/astro/src/components/blocks/Timeline.astro
@@ -37,7 +37,7 @@ const parsedContent = parseMarkdown(content);
 const sectionId = `timeline-${zIndex}`;
 ---
 <section class={cn("relative overflow-hidden", hasNotch && 'pb-notch', previousBlockHasNotch && 'mt-notch')} style={`z-index: ${zIndex}`}>
-  <div data-section-id={sectionId} class="relative bg-[#191958]">
+  <div data-section-id={sectionId} class={`relative bg-[#191958]`} data-notch-border-color={hasNotch ? '#ffffff' : undefined}>
     <div class="absolute top-0 left-24 w-[32rem] h-[32rem] rounded-full filter blur-3xl blur-circle"></div>
 
     <div class="relative mx-auto max-w-screen-xl px-8 py-48">
@@ -81,17 +81,3 @@ const sectionId = `timeline-${zIndex}`;
   </div>
 </section>
 
-
-{hasNotch && (
-  <script define:vars={{ sectionId }}>
-    const section = document.querySelector(`[data-section-id="${sectionId}"]`);
-    if (section) {
-      import('/src/lib/clipPath').then(({ applySectionClipPathWithBorder }) => {
-        applySectionClipPathWithBorder({
-          section,
-          borderColor: "#ffffff",
-        });
-      });
-    }
-  </script>
-)}

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ const language = 'en';
     <title>{meta.title}</title>
     <meta name="description" content={meta.description} />
     <meta name="keywords" content={meta.keywords} />
+    <script src="../scripts/notchInit.ts"></script>
   </head>
 
   <body>

--- a/astro/src/scripts/notchInit.ts
+++ b/astro/src/scripts/notchInit.ts
@@ -1,0 +1,15 @@
+import { applySectionClipPathWithBorder } from '@lib/clipPath';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const sectionsWithNotch = document.querySelectorAll('[data-notch-border-color]');
+  
+  sectionsWithNotch.forEach((section) => {
+    const borderColor = section.getAttribute('data-notch-border-color');
+    if (borderColor && section instanceof HTMLElement) {
+      applySectionClipPathWithBorder({
+        section,
+        borderColor
+      });
+    }
+  });
+}); 


### PR DESCRIPTION
Since we're using Github Pages, we can't use dynamic imports.
I updated the code to init the notch when DOM is ready.

<img width="720" height="40" alt="Capture d’écran 2025-07-16 à 23 05 41" src="https://github.com/user-attachments/assets/0bb43c48-5dc8-4da6-a2ba-779b1b647c98" />
