### PR TITLE
style: improve mobile responsiveness for hero block

### DIFF
--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -47,8 +47,8 @@ const logoColorUrl = getImageUrl(logoColor?.url, strapiUrl);
 ---
 
 <header class="absolute md:fixed text-slate-100 body-font z-20 w-full">
-   <div class="max-w-screen-xl mx-auto flex flex-wrap p-5 flex-row items-center justify-between px-8 py-12">
-     <a href={baseUrl} class="relative flex title-font font-medium items-center h-[102px] w-[204px]">
+   <div class="max-w-screen-xl mx-auto flex flex-wrap p-7 px-6 flex-row items-center justify-between xs:px-8 md:py-12">
+     <a href={baseUrl} class="relative flex title-font font-medium items-center h-[50px] w-[204px]">
       {logoWhiteUrl && (
         <Image src={logoWhiteUrl}
             id="logo-white"

--- a/astro/src/components/blocks/Hero.astro
+++ b/astro/src/components/blocks/Hero.astro
@@ -48,12 +48,10 @@ const parsedContent = parseMarkdown(description);
             loading="eager"
          />
       )}
-      <div class="max-w-screen-xl mx-auto flex flex-col items-start justify-center h-full w-full z-10 px-8">
+      <div class="max-w-screen-xl mx-auto flex flex-col items-start justify-center h-full w-full z-10 px-6 xs:px-8">
          <AvegaTitle title={title} />
-         <div class="text-white text-start mt-2 md:mt-6 text-md md:text-md max-w-3xl relative z-10">
-            <article set:html={parsedContent} />
-         </div>
-         <div class="mt-18 flex gap-4">
+         <div class="text-white text-start mt-3 md:mt-6 text-md md:text-md max-w-3xl relative z-10" set:html={parsedContent} />
+         <div class="mt-8 xs:mt-12 md:mt-18 flex gap-4">
             {buttons.map((button) => (
                <Button 
                   variant="shadow"

--- a/astro/src/components/shared/AvegaTitle.astro
+++ b/astro/src/components/shared/AvegaTitle.astro
@@ -14,7 +14,7 @@ const Tag = `h${level}` as keyof HTMLElementTagNameMap;
 
 // Define text sizes based on heading level
 const textSizeClasses = {
-	1: 'text-5xl md:text-6xl leading-18',
+	1: 'text-4xl xs:text-5xl md:text-6xl leading-12 xs:leading-16 md:leading-18',
 	2: 'text-4xl md:text-5xl leading-18',
 	3: 'text-3xl md:text-4xl leading-18',
 	4: 'text-2xl md:text-3xl',

--- a/astro/src/components/shared/Button.astro
+++ b/astro/src/components/shared/Button.astro
@@ -15,7 +15,7 @@ const { text, url, target, variant = "default", className } = Astro.props;
 const baseUrl = import.meta.env.BASE_URL;
 const href = getLinkUrl(url, baseUrl);
 
-const buttonVariants = cva("px-8 py-2.5 rounded-md font-semibold inline-flex", {
+const buttonVariants = cva("px-8 py-2.5 rounded-md font-semibold inline-flex text-center", {
     variants: {
         variant: {
             default: "bg-[#725CFA] text-white hover:bg-[#725CFA]/90",

--- a/astro/src/components/shared/DayCounter.astro
+++ b/astro/src/components/shared/DayCounter.astro
@@ -13,7 +13,7 @@ const timeDiff = target.getTime() - today.getTime();
 const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
 ---
 
-<div id="day-counter-container" class={cn("ml-4 px-10 py-2 bg-white/10 backdrop-blur-md rounded-lg border-1 border-white shadow-lg relative overflow-hidden", className)}>
+<div id="day-counter-container" class={cn("hidden xs:block ml-4 px-10 py-2 bg-white/10 backdrop-blur-md rounded-lg border-1 border-white shadow-lg relative overflow-hidden", className)}>
   <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
     <span id="day-counter-bg" class="text-white/10 avega text-7xl font-bold select-none">
       {daysDiff}

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -7,6 +7,7 @@
 }
 
 @theme {
+  --breakpoint-xs: 30rem;
   --animate-marquee: marquee 5s linear infinite;
   @keyframes marquee {
     0% {


### PR DESCRIPTION
This pull request introduces several responsive design improvements and minor UI adjustments to enhance the user experience across different screen sizes. The changes primarily focus on updating styles, spacing, and layout behavior for better alignment with smaller devices.

### Responsive design improvements:
* Added a new `--breakpoint-xs` variable (`30rem`) to define extra-small breakpoints in `astro/src/styles/global.css` for consistent responsive styling.
* Updated various components to include `xs:` responsive classes for better spacing and layout on smaller screens:
  - Adjusted padding and spacing in `Header.astro` (`astro/src/components/Header.astro`).
  - Modified layout and spacing in `Hero.astro` (`astro/src/components/blocks/Hero.astro`).
  - Added `xs:` responsive text sizes and line heights for heading level 1 in `AvegaTitle.astro` (`astro/src/components/shared/AvegaTitle.astro`).
  - Made the `DayCounter` component hidden on extra-small screens in `DayCounter.astro` (`astro/src/components/shared/DayCounter.astro`).

### Minor UI adjustments:
* Added `text-center` to button variants for consistent alignment in `Button.astro` (`astro/src/components/shared/Button.astro`).