### PR TITLE
feat: add header and textBlock components

### DIFF
--- a/astro/src/components/blocks/BlockManager.astro
+++ b/astro/src/components/blocks/BlockManager.astro
@@ -8,6 +8,8 @@ import GridList from "./GridList.astro";
 import Timeline from "./Timeline.astro";
 import Highlight from "./Highlight.astro";
 import Banner from "./Banner.astro";
+import Header from "./Header.astro";
+import TextBlock from "./TextBlock.astro";
 
 interface Block {
 	__component: string;
@@ -32,6 +34,8 @@ const componentMap: Record<string, any> = {
 	"blocks.timeline": Timeline,
 	"blocks.highlight": Highlight,
 	"blocks.banner": Banner,
+	"blocks.header": Header,
+	"blocks.text-block": TextBlock,
 };
 ---
 

--- a/astro/src/components/blocks/Header.astro
+++ b/astro/src/components/blocks/Header.astro
@@ -1,0 +1,40 @@
+---
+import { getImageUrl } from "@lib/imageUtils";
+import AvegaTitle from "../shared/AvegaTitle.astro";
+import Button from "../shared/Button.astro";
+
+interface Props {
+  title: string;
+  backgroundImage: {
+      url: string;
+      alternativeText: string;
+  };
+}
+
+const { title, backgroundImage } = Astro.props;
+
+const strapiUrl = import.meta.env.STRAPI_URL;
+
+const backgroundImageUrl = getImageUrl(backgroundImage?.url, strapiUrl);
+---
+<section 
+  style={{
+    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    backgroundRepeat: "no-repeat",
+  }}
+>
+
+  
+  <div class="mx-auto max-w-screen-xl py-10 px-6 xs:px-8 sm:py-12 relative z-10">
+    <Button 
+        text="Retour"
+        url="/"
+        target="_self"
+        variant="outline"
+        className="mb-4"
+    />
+    <AvegaTitle title={title} />
+  </div>
+</section> 

--- a/astro/src/components/blocks/TextBlock.astro
+++ b/astro/src/components/blocks/TextBlock.astro
@@ -1,0 +1,20 @@
+---
+import { configureMarkdown, parseMarkdown } from "@lib/markdown";
+
+interface Props {
+    content: string;
+}
+
+const { content } = Astro.props;
+
+// Configure marked for markdown parsing
+configureMarkdown();
+const parsedContent = parseMarkdown(content);
+
+---
+<section 
+  class="markdown"
+  data-header-color={true}
+>
+  <div class="mx-auto max-w-screen-xl py-10 px-6 xs:px-8 sm:py-12 relative z-10" set:html={parsedContent}></div>
+</section> 

--- a/astro/src/layouts/PageLayout.astro
+++ b/astro/src/layouts/PageLayout.astro
@@ -2,12 +2,18 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import Header from '@components/Header.astro';
 import Footer from '@components/Footer.astro';
+
+interface Props {
+  shownNavbar?: boolean;
+}
+
+const { shownNavbar = true } = Astro.props as Props;
 ---
 
 <BaseLayout>
   <div class="page">
     <slot name="header">
-      <Header />
+      {shownNavbar && <Header />}
     </slot>
     <section class="content">
       <main>

--- a/astro/src/pages/[slug].astro
+++ b/astro/src/pages/[slug].astro
@@ -37,6 +37,6 @@ export async function getStaticPaths() {
 
 const { blocks } = Astro.props;
 ---
-<PageLayout>
+<PageLayout shownNavbar={false}>
   <BlockManager blocks={blocks} />
 </PageLayout>

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -43,3 +43,33 @@ html {
     clip-path: url(#ticket-shape);
   }
 }
+
+.markdown {
+  h2 {
+    @apply text-2xl font-bold my-4;
+  }
+  h3 {
+    @apply text-xl font-bold my-3;
+  }
+  h4 {
+    @apply text-lg font-bold my-2;
+  }
+  p {
+    @apply text-base prose;
+  }
+  ul {
+    @apply list-disc pl-4;
+  }
+  ol {
+    @apply list-decimal pl-4;
+  }
+  li {
+    @apply my-2;
+  }
+  a {
+    @apply text-blue-500 underline;
+  }
+  hr {
+    @apply my-8 opacity-20;
+  }
+}

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -25,7 +25,9 @@
         "blocks.grid-list",
         "blocks.timeline",
         "blocks.highlight",
-        "blocks.banner"
+        "blocks.banner",
+        "blocks.header",
+        "blocks.text-block"
       ]
     }
   }

--- a/strapi/src/components/blocks/header.json
+++ b/strapi/src/components/blocks/header.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_blocks_headers",
+  "info": {
+    "displayName": "Header"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "backgroundImage": {
+      "allowedTypes": [
+        "images",
+        "files"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/strapi/src/components/blocks/text-block.json
+++ b/strapi/src/components/blocks/text-block.json
@@ -1,0 +1,12 @@
+{
+  "collectionName": "components_blocks_text_blocks",
+  "info": {
+    "displayName": "TextBlock"
+  },
+  "options": {},
+  "attributes": {
+    "content": {
+      "type": "richtext"
+    }
+  }
+}

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-23T09:07:36.860Z"
+    "x-generation-date": "2025-07-23T13:51:46.771Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -6344,6 +6344,12 @@
                     },
                     {
                       "$ref": "#/components/schemas/BlocksBannerComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlocksHeaderComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlocksTextBlockComponent"
                     }
                   ]
                 },
@@ -6358,7 +6364,9 @@
                     "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
                     "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
                     "blocks.highlight": "#/components/schemas/BlocksHighlightComponent",
-                    "blocks.banner": "#/components/schemas/BlocksBannerComponent"
+                    "blocks.banner": "#/components/schemas/BlocksBannerComponent",
+                    "blocks.header": "#/components/schemas/BlocksHeaderComponent",
+                    "blocks.text-block": "#/components/schemas/BlocksTextBlockComponent"
                   }
                 }
               },
@@ -6460,6 +6468,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/BlocksBannerComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/BlocksHeaderComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/BlocksTextBlockComponent"
                 }
               ]
             },
@@ -6474,7 +6488,9 @@
                 "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
                 "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
                 "blocks.highlight": "#/components/schemas/BlocksHighlightComponent",
-                "blocks.banner": "#/components/schemas/BlocksBannerComponent"
+                "blocks.banner": "#/components/schemas/BlocksBannerComponent",
+                "blocks.header": "#/components/schemas/BlocksHeaderComponent",
+                "blocks.text-block": "#/components/schemas/BlocksTextBlockComponent"
               }
             }
           },
@@ -6559,6 +6575,12 @@
                       },
                       {
                         "$ref": "#/components/schemas/BlocksBannerComponent"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BlocksHeaderComponent"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BlocksTextBlockComponent"
                       }
                     ]
                   },
@@ -6573,7 +6595,9 @@
                       "blocks.grid-list": "#/components/schemas/BlocksGridListComponent",
                       "blocks.timeline": "#/components/schemas/BlocksTimelineComponent",
                       "blocks.highlight": "#/components/schemas/BlocksHighlightComponent",
-                      "blocks.banner": "#/components/schemas/BlocksBannerComponent"
+                      "blocks.banner": "#/components/schemas/BlocksBannerComponent",
+                      "blocks.header": "#/components/schemas/BlocksHeaderComponent",
+                      "blocks.text-block": "#/components/schemas/BlocksTextBlockComponent"
                     }
                   }
                 },
@@ -8128,6 +8152,169 @@
             }
           },
           "anchor": {
+            "type": "string"
+          }
+        }
+      },
+      "BlocksHeaderComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "blocks.header"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "backgroundImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "BlocksTextBlockComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "blocks.text-block"
+            ]
+          },
+          "content": {
             "type": "string"
           }
         }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -64,6 +64,17 @@ export interface BlocksGridList extends Struct.ComponentSchema {
   };
 }
 
+export interface BlocksHeader extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_headers';
+  info: {
+    displayName: 'Header';
+  };
+  attributes: {
+    backgroundImage: Schema.Attribute.Media<'images' | 'files'>;
+    title: Schema.Attribute.String;
+  };
+}
+
 export interface BlocksHero extends Struct.ComponentSchema {
   collectionName: 'components_heroes';
   info: {
@@ -138,6 +149,16 @@ export interface BlocksTeam extends Struct.ComponentSchema {
   };
 }
 
+export interface BlocksTextBlock extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_text_blocks';
+  info: {
+    displayName: 'TextBlock';
+  };
+  attributes: {
+    content: Schema.Attribute.RichText;
+  };
+}
+
 export interface BlocksTimeline extends Struct.ComponentSchema {
   collectionName: 'components_blocks_timelines';
   info: {
@@ -194,10 +215,12 @@ declare module '@strapi/strapi' {
       'blocks.cards': BlocksCards;
       'blocks.features': BlocksFeatures;
       'blocks.grid-list': BlocksGridList;
+      'blocks.header': BlocksHeader;
       'blocks.hero': BlocksHero;
       'blocks.highlight': BlocksHighlight;
       'blocks.stats': BlocksStats;
       'blocks.team': BlocksTeam;
+      'blocks.text-block': BlocksTextBlock;
       'blocks.timeline': BlocksTimeline;
       'components.card': ComponentsCard;
       'components.link': ComponentsLink;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -486,6 +486,8 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         'blocks.timeline',
         'blocks.highlight',
         'blocks.banner',
+        'blocks.header',
+        'blocks.text-block',
       ]
     >;
     createdAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
This pull request introduces two new block components, `Header` and `TextBlock`, to the Astro and Strapi codebases. It also updates the layout and styling to support these new components. Below are the key changes grouped by theme:

### New Block Components
* Added `Header` component (`astro/src/components/blocks/Header.astro`) to display a section with a title and background image. It includes a "Retour" button and uses shared components like `AvegaTitle` and `Button`.
* Added `TextBlock` component (`astro/src/components/blocks/TextBlock.astro`) to render rich text content using Markdown parsing utilities.

### Integration of New Blocks
* Updated `BlockManager.astro` to import and map the new `Header` and `TextBlock` components.
* Updated Strapi schema (`strapi/src/api/page/content-types/page/schema.json`) to include `blocks.header` and `blocks.text-block` in the list of allowed block types.
* Added new Strapi component definitions for `Header` (`strapi/src/components/blocks/header.json`) and `TextBlock` (`strapi/src/components/blocks/text-block.json`).

### Layout and Styling Updates
* Modified `PageLayout.astro` to conditionally display the `Header` component based on a new `shownNavbar` prop.
* Updated a specific page (`astro/src/pages/[slug].astro`) to hide the navbar by passing `shownNavbar={false}` to `PageLayout`.
* Added global styles for the `.markdown` class to style headings, paragraphs, lists, links, and other elements rendered by the `TextBlock` component.

### Documentation Updates
* Updated Strapi's OpenAPI documentation (`strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json`) to include schemas and references for `BlocksHeaderComponent` and `BlocksTextBlockComponent`.