### PR TITLE
fix: switch card description from string to richText

### DIFF
--- a/astro/src/components/shared/Card.astro
+++ b/astro/src/components/shared/Card.astro
@@ -4,6 +4,7 @@ import AvegaTitle from "./AvegaTitle.astro";
 import { getImageUrl } from "@lib/imageUtils";
 import { cn } from "@lib/cn";
 import Button from "./Button.astro";
+import { configureMarkdown, parseMarkdown } from "@lib/markdown";
 
 interface LinkItem {
 	title: string;
@@ -38,6 +39,9 @@ const { title, subtitle, description, icon, iconSize, iconClassName, backgroundI
 
 const iconUrl = getImageUrl(icon?.url, strapiUrl);
 const imageUrl = getImageUrl(backgroundImage?.url, strapiUrl);
+
+configureMarkdown();
+const parsedDescription = parseMarkdown(description);
 ---
 
 <div class={cn("relative size-full p-8 pb-10 text-center rounded-2xl backdrop-blur-xs bg-[#424242]/10 border border-white shadow-xl hover:shadow-2xl transition-all duration-300 group hover:scale-105 max-w-5xl", className)}
@@ -69,9 +73,7 @@ const imageUrl = getImageUrl(backgroundImage?.url, strapiUrl);
 	)}
 
 	{description && (
-		<p class="relative mt-4 text-white/90 leading-relaxed text-center text-sm mx-auto">
-			{description}
-		</p>
+		<div class="relative mt-4 text-white/90 leading-relaxed text-center text-sm mx-auto" set:html={parsedDescription}></div>
 	)}
 
 	{button && (

--- a/strapi/src/components/components/card.json
+++ b/strapi/src/components/components/card.json
@@ -13,9 +13,6 @@
     "subtitle": {
       "type": "string"
     },
-    "description": {
-      "type": "string"
-    },
     "backgroundImage": {
       "type": "media",
       "multiple": false,
@@ -46,6 +43,9 @@
         "md",
         "lg"
       ]
+    },
+    "description": {
+      "type": "richtext"
     }
   }
 }

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-23T16:04:39.814Z"
+    "x-generation-date": "2025-07-23T23:07:52.216Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -7292,9 +7292,6 @@
           "subtitle": {
             "type": "string"
           },
-          "description": {
-            "type": "string"
-          },
           "backgroundImage": {
             "type": "object",
             "properties": {
@@ -7563,6 +7560,9 @@
               "md",
               "lg"
             ]
+          },
+          "description": {
+            "type": "string"
           }
         }
       },

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -184,7 +184,7 @@ export interface ComponentsCard extends Struct.ComponentSchema {
   attributes: {
     backgroundImage: Schema.Attribute.Media<'images' | 'files'>;
     button: Schema.Attribute.Component<'components.link', false>;
-    description: Schema.Attribute.String;
+    description: Schema.Attribute.RichText;
     icon: Schema.Attribute.Media<'images' | 'files'>;
     iconSize: Schema.Attribute.Enumeration<['sm', 'md', 'lg']>;
     subtitle: Schema.Attribute.String;


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of the `description` field in the `Card` component by switching from plain text to rich text with Markdown support. It also updates the corresponding Strapi schema and documentation to reflect this change. The most important changes are outlined below:

### Enhancements to Markdown Support in the `Card` Component:
* Added `configureMarkdown` and `parseMarkdown` functions from `@lib/markdown` to process the `description` field in the `Card` component. 
* Replaced the plain text rendering of the `description` field with a `set:html` directive to render parsed Markdown content. 

### Updates to Strapi Schema:
* Changed the `description` field type in the `Card` component schema from `string` to `richtext` to support rich text content.

### Documentation Updates:
* Updated the Strapi documentation to reflect the change in the `description` field type from `string` to `richtext`.