### PR TITLE
style: improve hero component on mobile devices

### DIFF
--- a/astro/src/components/blocks/Hero.astro
+++ b/astro/src/components/blocks/Hero.astro
@@ -20,6 +20,14 @@ interface Props {
       url: string;
       alternativeText: string;
    };
+   mobileBackgroundImage?: {
+      url: string;
+      alternativeText: string;
+   };
+   mobileObjectImage?: {
+      url: string;
+      alternativeText: string;
+   };
    buttons: LinkItem[];
    hasNotch: boolean;
    previousBlockHasNotch: boolean;
@@ -27,9 +35,11 @@ interface Props {
 
 const strapiUrl = import.meta.env.STRAPI_URL;
 
-const { anchor, zIndex, title, description, backgroundImage, buttons, hasNotch, previousBlockHasNotch } = Astro.props;
+const { anchor, zIndex, title, description, backgroundImage, mobileBackgroundImage, mobileObjectImage, buttons, hasNotch, previousBlockHasNotch } = Astro.props;
 
 const imageUrl = getImageUrl(backgroundImage.url, strapiUrl);
+const mobileBackgroundUrl = mobileBackgroundImage ? getImageUrl(mobileBackgroundImage.url, strapiUrl) : null;
+const mobileObjectUrl = mobileObjectImage ? getImageUrl(mobileObjectImage.url, strapiUrl) : null;
 
 // Configure marked to properly handle markdown
 configureMarkdown();
@@ -40,18 +50,45 @@ const parsedContent = parseMarkdown(description);
    zIndex: zIndex
 }}>
    <div class={`h-full overflow-hidden relative flex flex-col items-center justify-center`} data-notch-border-color={hasNotch ? '#6336E4' : undefined}>
+      {/* Desktop background image */}
       {imageUrl && (
          <Image src={imageUrl}
             alt=""
-            class="absolute inset-0 w-full h-full object-cover z-0"
+            class="absolute inset-0 w-full h-full object-cover z-0 hidden md:block"
             width="1920"
             height="1080"
             loading="eager"
          />
       )}
+      {/* Mobile background image */}
+      {mobileBackgroundUrl ? (
+         <Image src={mobileBackgroundUrl}
+            alt={mobileBackgroundImage?.alternativeText || ""}
+            class="absolute inset-0 w-full h-full object-cover z-0 block md:hidden"
+            width="390"
+            height="844"
+            loading="eager"
+         />
+      ) : (
+         <img src="/bg-hero-mobile.png"
+            alt=""
+            class="absolute inset-0 w-full h-full object-cover z-0 block md:hidden"
+            loading="eager"
+         />
+      )}
+      {/* Mobile object image */}
+      {mobileObjectUrl && (
+         <Image src={mobileObjectUrl}
+            alt={mobileObjectImage?.alternativeText || ""}
+            class="absolute top-1/3 right-2 -translate-y-1/2 w-60 h-auto z-5 block md:hidden"
+            width="240"
+            height="300"
+            loading="eager"
+         />
+      )}
       <div class="max-w-screen-xl mx-auto flex flex-col items-start justify-center h-full w-full z-10 px-6 xs:px-8">
          <AvegaTitle title={title} />
-         <div class="text-white text-start mt-3 md:mt-6 text-md md:text-md max-w-3xl relative z-10" set:html={parsedContent} />
+         <div class="text-white text-start mt-4 md:mt-6 text-md md:text-md max-w-3xl relative z-10" set:html={parsedContent} />
          <div class="mt-8 xs:mt-12 md:mt-18 flex gap-4">
             {buttons.map((button) => (
                <Button 

--- a/strapi/src/components/blocks/hero.json
+++ b/strapi/src/components/blocks/hero.json
@@ -35,6 +35,22 @@
     },
     "anchor": {
       "type": "string"
+    },
+    "mobileBackgroundImage": {
+      "allowedTypes": [
+        "images",
+        "files"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "mobileObjectImage": {
+      "allowedTypes": [
+        "images",
+        "files"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-23T23:07:52.216Z"
+    "x-generation-date": "2025-08-25T12:26:25.488Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -6826,6 +6826,264 @@
           },
           "anchor": {
             "type": "string"
+          },
+          "mobileBackgroundImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "mobileObjectImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -90,6 +90,8 @@ export interface BlocksHero extends Struct.ComponentSchema {
     buttons: Schema.Attribute.Component<'components.link', true>;
     description: Schema.Attribute.RichText;
     hasNotch: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    mobileBackgroundImage: Schema.Attribute.Media<'images' | 'files'>;
+    mobileObjectImage: Schema.Attribute.Media<'images' | 'files'>;
     title: Schema.Attribute.String;
   };
 }


### PR DESCRIPTION
This pull request adds support for mobile-specific images to the Hero block, improving how the component displays on mobile devices. The changes introduce optional properties for a mobile background image and a mobile object image, update the Astro component to conditionally render these images for mobile screens, and extend the Strapi schema and documentation to support these new fields.

**Hero block mobile image support:**

* Added optional `mobileBackgroundImage` and `mobileObjectImage` properties to the `Hero.astro` component props, enabling mobile-specific image rendering.
* Updated the Hero block markup to conditionally display the mobile background image and mobile object image on mobile devices, with fallbacks for missing images.

**Strapi schema and documentation updates:**

* Extended the Strapi block schema (`hero.json`) to define `mobileBackgroundImage` and `mobileObjectImage` as media fields, allowing single image uploads for each.
* Updated Strapi OpenAPI documentation to include detailed definitions for `mobileBackgroundImage` and `mobileObjectImage` properties in the Hero block, ensuring API consumers are aware of the new fields.
* Updated the documentation generation date to reflect the new changes.