### PR TITLE
fix(astro:Hero): ensure mobile images are only displayed when both ar…

### DIFF
--- a/astro/src/components/blocks/Hero.astro
+++ b/astro/src/components/blocks/Hero.astro
@@ -41,6 +41,9 @@ const imageUrl = getImageUrl(backgroundImage.url, strapiUrl);
 const mobileBackgroundUrl = mobileBackgroundImage ? getImageUrl(mobileBackgroundImage.url, strapiUrl) : null;
 const mobileObjectUrl = mobileObjectImage ? getImageUrl(mobileObjectImage.url, strapiUrl) : null;
 
+// Only show mobile version if both mobile images are present
+const hasBothMobileImages = mobileBackgroundUrl && mobileObjectUrl;
+
 // Configure marked to properly handle markdown
 configureMarkdown();
 const parsedContent = parseMarkdown(description);
@@ -50,18 +53,18 @@ const parsedContent = parseMarkdown(description);
    zIndex: zIndex
 }}>
    <div class={`h-full overflow-hidden relative flex flex-col items-center justify-center`} data-notch-border-color={hasNotch ? '#6336E4' : undefined}>
-      {/* Desktop background image */}
+      {/* Desktop background image - hidden on mobile only if both mobile images are present */}
       {imageUrl && (
          <Image src={imageUrl}
             alt=""
-            class="absolute inset-0 w-full h-full object-cover z-0 hidden md:block"
+            class={`absolute inset-0 w-full h-full object-cover z-0 ${hasBothMobileImages ? 'hidden md:block' : ''}`}
             width="1920"
             height="1080"
             loading="eager"
          />
       )}
-      {/* Mobile background image */}
-      {mobileBackgroundUrl ? (
+      {/* Mobile background image - only shown if both mobile images are present */}
+      {hasBothMobileImages && (
          <Image src={mobileBackgroundUrl}
             alt={mobileBackgroundImage?.alternativeText || ""}
             class="absolute inset-0 w-full h-full object-cover z-0 block md:hidden"
@@ -69,15 +72,9 @@ const parsedContent = parseMarkdown(description);
             height="844"
             loading="eager"
          />
-      ) : (
-         <img src="/bg-hero-mobile.png"
-            alt=""
-            class="absolute inset-0 w-full h-full object-cover z-0 block md:hidden"
-            loading="eager"
-         />
       )}
-      {/* Mobile object image */}
-      {mobileObjectUrl && (
+      {/* Mobile object image - only shown if both mobile images are present */}
+      {hasBothMobileImages && (
          <Image src={mobileObjectUrl}
             alt={mobileObjectImage?.alternativeText || ""}
             class="absolute top-1/3 right-2 -translate-y-1/2 w-60 h-auto z-5 block md:hidden"


### PR DESCRIPTION
This pull request updates the logic for rendering mobile and desktop images in the `Hero.astro` component to ensure a more consistent visual experience across devices. The main change is to only show the mobile-specific background and object images if both are available, and to hide the desktop image on mobile in that case.

**Image rendering logic improvements:**

* Added a `hasBothMobileImages` flag to check for the presence of both mobile background and object images, ensuring mobile-specific rendering only occurs when both images are available.
* Updated conditional rendering so the desktop background image is hidden on mobile only if both mobile images are present.
* Changed mobile background and object images to render only if both are present, removing fallback logic for missing images.…e present