### PR TITLE
fix: improve semantic HTML structure and accessibility

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -69,7 +69,7 @@ const iconUrl = getImageUrl(icon?.url, strapiUrl);
                 </li>
             ))}
 
-            <a href={linkedinURL} target="_blank" class="bg-[#725CFA]/20 hover:bg-[#725CFA]/10 font-bold size-7 flex items-center justify-center rounded-sm flex-shrink-0">
+            <a href={linkedinURL} target="_blank" aria-label="Suivez-nous sur LinkedIn" class="bg-[#725CFA]/20 hover:bg-[#725CFA]/10 font-bold size-7 flex items-center justify-center rounded-sm flex-shrink-0">
                 <Linkedin />
             </a>
         </nav>

--- a/astro/src/components/blocks/GridList.astro
+++ b/astro/src/components/blocks/GridList.astro
@@ -39,7 +39,7 @@ const parsedContent = parseMarkdown(content);
   <div class={`relative bg-white`} data-notch-border-color={hasNotch ? '#ffffff' : undefined}>
     <div class="mx-auto max-w-screen-xl px-6 xs:px-8 py-24 xs:py-32 md:py-48">
       {title && (
-        <AvegaTitle title={title} level={4} color="#725CFA" />
+        <AvegaTitle title={title} level={2} size={4} color="#725CFA" />
       )}
 
       <div class="mt-4 prose prose-strong:font-bold max-w-none">

--- a/astro/src/components/blocks/Highlight.astro
+++ b/astro/src/components/blocks/Highlight.astro
@@ -29,7 +29,7 @@ const parsedContent = parseMarkdown(content);
     <div class="mx-auto max-w-screen-xl px-6 xs:px-8 sm:px-16 py-24 xs:py-32 md:py-48 relative z-10 flex flex-col lg:flex-row-reverse justify-center items-center gap-32">
         <div class="max-w-lg md:max-w-none">
             {title && (
-                <AvegaTitle title={title} level={4} color="#725CFA" />
+                <AvegaTitle title={title} level={2} size={4} color="#725CFA" />
             )}
 
             <div class="mt-4 prose prose-strong:font-bold max-w-none" set:html={parsedContent}></div>

--- a/astro/src/components/blocks/Program.astro
+++ b/astro/src/components/blocks/Program.astro
@@ -78,7 +78,8 @@ const { anchor, zIndex, StageProgram, hasNotch, previousBlockHasNotch } = Astro.
 					<div class="mb-16 last:mb-0">
 						<AvegaTitle
 							title={stage.title}
-							level={5}
+							level={2}
+							size={5}
 							color="#CA5FF9"
 							className="mb-8"
 						/>
@@ -107,7 +108,8 @@ const { anchor, zIndex, StageProgram, hasNotch, previousBlockHasNotch } = Astro.
 											<div class="conference-title-no-shadow">
 												<AvegaTitle
 													title={conference.title}
-													level={6}
+													level={3}
+													size={6}
 													color="#ffffff"
 													className="line-clamp-2 !text-md"
 												/>

--- a/astro/src/components/blocks/Sponsors.astro
+++ b/astro/src/components/blocks/Sponsors.astro
@@ -72,7 +72,8 @@ const sponsorTypes = (Object.keys(sponsorsByType) as SponsorType[]).filter(
 			{title && (
 				<AvegaTitle
 					title={title}
-					level={4}
+					level={2}
+					size={4}
 					color="#725CFA"
 					className="mb-8"
 				/>
@@ -89,7 +90,8 @@ const sponsorTypes = (Object.keys(sponsorsByType) as SponsorType[]).filter(
 					<div>
 						<AvegaTitle
 							title={typeTitles[type]}
-							level={5}
+							level={3}
+							size={5}
 							color="#CA5FF9"
 							className="mb-8 mx-auto text-center"
 						/>

--- a/astro/src/components/blocks/Stats.astro
+++ b/astro/src/components/blocks/Stats.astro
@@ -117,7 +117,7 @@ const currentLayout = gridLayouts[statsCount as keyof typeof gridLayouts] || gri
         <div class="order-2 lg:order-2">
           <div class="max-w-lg md:max-w-none">
             {title && (
-              <AvegaTitle title={title} level={4} className="mt-0 xs:mt-4" />
+              <AvegaTitle title={title} level={2} size={4} className="mt-0 xs:mt-4" />
             )}
 
             <div class="mt-4 prose prose-strong:font-bold max-w-none prose-invert">
@@ -133,7 +133,7 @@ const currentLayout = gridLayouts[statsCount as keyof typeof gridLayouts] || gri
                   url={ctaLink ?? ""}
                 />
 
-                <a href="https://www.linkedin.com/company/normandie-ai/" target="_blank" class="border-[#ffffff] border-1 font-bold size-11 flex items-center justify-center rounded-md flex-shrink-0 hover:bg-white/10">
+                <a href="https://www.linkedin.com/company/normandie-ai/" target="_blank" aria-label="Suivez-nous sur LinkedIn" class="border-[#ffffff] border-1 font-bold size-11 flex items-center justify-center rounded-md flex-shrink-0 hover:bg-white/10">
                   <Linkedin color="#ffffff" />
                 </a>
               </div>

--- a/astro/src/components/blocks/Team.astro
+++ b/astro/src/components/blocks/Team.astro
@@ -55,7 +55,7 @@ const cardImageUrl = getImageUrl(cardImage?.url, strapiUrl);
   <div class={`relative bg-white`} data-notch-border-color={hasNotch ? '#ff00ff' : undefined}>
     <div class="max-w-screen-xl mx-auto px-6 xs:px-8 py-24 xs:py-32 md:py-48">
       <div class="mb-20">
-        <AvegaTitle title={title} color="#725CFA" level={4} />
+        <AvegaTitle title={title} color="#725CFA" level={2} size={4} />
         <div class="leading-relaxed text-base mt-5" set:html={parsedContent} />
       </div>
 

--- a/astro/src/components/blocks/Timeline.astro
+++ b/astro/src/components/blocks/Timeline.astro
@@ -44,7 +44,7 @@ const parsedContent = parseMarkdown(content);
 
     <div class="relative mx-auto max-w-screen-xl px-6 xs:px-8 py-24 xs:py-32 md:py-48">
       {title && (
-        <AvegaTitle title={title} level={4} />
+        <AvegaTitle title={title} level={2} size={4} />
       )}
 
       <div class="mt-4 prose prose-strong:font-bold max-w-none prose-invert">

--- a/astro/src/components/shared/AvegaTitle.astro
+++ b/astro/src/components/shared/AvegaTitle.astro
@@ -5,14 +5,15 @@ import { cn } from "@lib/cn";
 interface Props {
 	title: string;
 	level?: 1 | 2 | 3 | 4 | 5 | 6;
+	size?: 1 | 2 | 3 | 4 | 5 | 6;
 	color?: string;
 	className?: string;
 }
 
-const { title, level = 1, className, color = "#ffffff" } = Astro.props;
+const { title, level = 1, size, className, color = "#ffffff" } = Astro.props;
 const Tag = `h${level}` as keyof HTMLElementTagNameMap;
 
-// Define text sizes based on heading level
+// Define text sizes (independent of semantic level)
 const textSizeClasses = {
 	1: 'text-4xl xs:text-5xl md:text-6xl leading-12 xs:leading-16 md:leading-18',
 	2: 'text-4xl md:text-5xl leading-18',
@@ -22,7 +23,9 @@ const textSizeClasses = {
 	6: 'text-lg md:text-xl'
 };
 
-const sizeClass = textSizeClasses[level];
+// Use size prop if provided, otherwise fall back to level for backwards compatibility
+const visualSize = size ?? level;
+const sizeClass = textSizeClasses[visualSize];
 
 const shadowColor = hexToRgba(color, 0.16);
 ---


### PR DESCRIPTION
- Separate visual size from semantic heading levels in AvegaTitle component
- Add optional 'size' prop to control appearance independently of HTML semantics
- Update all block components to use correct heading hierarchy (h1 > h2 > h3)
- Add aria-label to LinkedIn icon links for better accessibility