### PR TITLE
fix(Sponsors): increase sponsor logo height from 90px to 120px

### DIFF
--- a/astro/src/components/blocks/Sponsors.astro
+++ b/astro/src/components/blocks/Sponsors.astro
@@ -114,14 +114,14 @@ const sponsorTypes = (Object.keys(sponsorsByType) as SponsorType[]).filter(
 										href={sponsor.url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="transition-transform hover:scale-110 h-[90px] w-[200px]"
+										class="transition-transform hover:scale-110 h-[120px] w-[200px]"
 									>
 										{logoImage && logoUrl && (
 											<Image
 												src={logoUrl}
 												alt={logoImage.alternativeText || sponsor.name}
 												width={200}
-												height={90}
+												height={120}
 												class="h-full w-full object-contain"
 											/>
 										)}


### PR DESCRIPTION
This pull request makes a small UI adjustment to the sponsor logo display. The height of the sponsor logo area and images has been increased to improve visibility.

* Increased the height of sponsor logo containers and images from 90px to 120px in `Sponsors.astro` for better visual presentation.