### PR TITLE
fix(Sponsors): increase sponsor logo height to 130px

### DIFF
--- a/astro/src/components/blocks/Sponsors.astro
+++ b/astro/src/components/blocks/Sponsors.astro
@@ -114,14 +114,14 @@ const sponsorTypes = (Object.keys(sponsorsByType) as SponsorType[]).filter(
 										href={sponsor.url}
 										target="_blank"
 										rel="noopener noreferrer"
-										class="transition-transform hover:scale-110 h-[120px] w-[200px]"
+										class="transition-transform hover:scale-110 h-[130px] w-[200px]"
 									>
 										{logoImage && logoUrl && (
 											<Image
 												src={logoUrl}
 												alt={logoImage.alternativeText || sponsor.name}
 												width={200}
-												height={120}
+												height={130}
 												class="h-full w-full object-contain"
 											/>
 										)}


### PR DESCRIPTION
This pull request makes a minor adjustment to the appearance of sponsor logos in the `Sponsors.astro` component by increasing their display height.

- Increased the height of sponsor logo containers and images from 120px to 130px to improve visual consistency and presentation.